### PR TITLE
Remove dependency on Shed.class from ConfigReader

### DIFF
--- a/src/main/java/app/ToolRentalApp.java
+++ b/src/main/java/app/ToolRentalApp.java
@@ -3,6 +3,7 @@ package app;
 import office.Checkout;
 import office.Shed;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.Scanner;
@@ -30,6 +31,9 @@ public class ToolRentalApp {
                 ra.printRentalAgreement();
                 System.out.println();
             }
+        } catch (IOException e) {
+            System.out.println("Error: unable to load data file(s), unable to continue.");
+            System.exit(-1);
         }
     }
 
@@ -57,7 +61,7 @@ public class ToolRentalApp {
     }
 
     @SuppressWarnings("SameParameterValue")
-    private static String queryForToolCode(Scanner scanner, String message) {
+    private static String queryForToolCode(Scanner scanner, String message) throws IOException {
         String code = null;
         while (code == null) {
             System.out.print(message);

--- a/src/main/java/config/ConfigReader.java
+++ b/src/main/java/config/ConfigReader.java
@@ -1,17 +1,18 @@
 package config;
 
-import office.Shed;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
-import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
 
 public class ConfigReader {
-    public static <T> T readConfig(String filename, Class<T> clazz) {
-        Constructor constructor = new Constructor(clazz, new LoaderOptions());
-        Yaml yaml = new Yaml(constructor);
-        InputStream inputStream = Shed.class.getClassLoader().getResourceAsStream(filename);
-        return yaml.load(inputStream);
+    public static <T> T readConfig(String filename, Class<T> clazz) throws IOException {
+        try (FileInputStream inputStream = new FileInputStream("src/main/resources/" + filename)){
+            Constructor constructor = new Constructor(clazz, new LoaderOptions());
+            Yaml yaml = new Yaml(constructor);
+            return yaml.load(inputStream);
+        }
     }
 }

--- a/src/main/java/office/ChargeSchedule.java
+++ b/src/main/java/office/ChargeSchedule.java
@@ -2,6 +2,7 @@ package office;
 
 import config.ConfigReader;
 
+import java.io.IOException;
 import java.util.List;
 
 /***
@@ -18,14 +19,14 @@ public class ChargeSchedule {
         this.charges = charges;
     }
 
-    private static ChargeSchedule loadChargeSchedule() {
+    private static ChargeSchedule loadChargeSchedule() throws IOException {
         if (chargeSchedule == null) {
             chargeSchedule = ConfigReader.readConfig(ChargeSchedule.FILE_NAME, ChargeSchedule.class);
         }
         return chargeSchedule;
     }
 
-    public static Charge getChargeForType(String type) {
+    public static Charge getChargeForType(String type) throws IOException {
         for (Charge charge : loadChargeSchedule().charges) {
             if (charge.getType().equals(type)) {
                 return charge;

--- a/src/main/java/office/Checkout.java
+++ b/src/main/java/office/Checkout.java
@@ -2,6 +2,7 @@ package office;
 
 import config.Common;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
@@ -26,7 +27,7 @@ public class Checkout {
     private BigDecimal discountAmount;
     private BigDecimal finalCharge;
 
-    public Checkout(Tool tool, int rentalDays, LocalDate checkoutDate, int discountPercent) throws IllegalArgumentException {
+    public Checkout(Tool tool, int rentalDays, LocalDate checkoutDate, int discountPercent) throws IllegalArgumentException, IOException {
         validateInputs(rentalDays, discountPercent);
         this.tool = tool;
         this.rentalDays = rentalDays;
@@ -48,7 +49,7 @@ public class Checkout {
      * The sequencing of the below actions are important. For example, attempting to calculate pre-discount charge
      * before calculating the charge days or the daily charge rate will result in bad data.
      */
-    private void init() {
+    private void init() throws IOException {
         // add the number of rental days to the checkout date to get dueDate
         dueDate = checkoutDate.plusDays(rentalDays);
         Charge toolCharge = ChargeSchedule.getChargeForType(tool.getType());

--- a/src/main/java/office/Shed.java
+++ b/src/main/java/office/Shed.java
@@ -2,6 +2,7 @@ package office;
 
 import config.ConfigReader;
 
+import java.io.IOException;
 import java.util.List;
 
 import static config.Common.definedExitCode;
@@ -19,7 +20,7 @@ public class Shed {
         return tools;
     }
 
-    private static Shed loadShed() {
+    private static Shed loadShed() throws IOException {
         if (shed == null) {
             shed = ConfigReader.readConfig(Shed.FILE_NAME, Shed.class);
             // quick validation that 'exit' is never added as a tool code in the future
@@ -32,7 +33,7 @@ public class Shed {
         return shed;
     }
 
-    public static Tool getTool(String code) throws IllegalArgumentException {
+    public static Tool getTool(String code) throws IllegalArgumentException, IOException {
         for (Tool tool : loadShed().tools) {
             if (tool.getCode().equals(code)) {
                 return tool;

--- a/src/test/java/office/CheckoutTest.java
+++ b/src/test/java/office/CheckoutTest.java
@@ -44,7 +44,7 @@ class CheckoutTest {
     }
 
     @Test
-    void test_challenge_proof_test2() {
+    void test_challenge_proof_test2() throws Exception {
         // test values
         String code = "LADW";
         int rentalDays = 3;
@@ -89,7 +89,7 @@ class CheckoutTest {
     }
 
     @Test
-    void test_challenge_proof_test3() {
+    void test_challenge_proof_test3() throws Exception {
         // test values
         String code = "CHNS";
         int rentalDays = 5;
@@ -134,7 +134,7 @@ class CheckoutTest {
     }
 
     @Test
-    void test_challenge_proof_test4() {
+    void test_challenge_proof_test4() throws Exception {
         // test values
         String code = "JAKD";
         int rentalDays = 6;
@@ -179,7 +179,7 @@ class CheckoutTest {
     }
 
     @Test
-    void test_challenge_proof_test5() {
+    void test_challenge_proof_test5() throws Exception {
         // test values
         String code = "JAKR";
         int rentalDays = 9;
@@ -224,7 +224,7 @@ class CheckoutTest {
     }
 
     @Test
-    void test_challenge_proof_test6() {
+    void test_challenge_proof_test6() throws Exception {
         // test values
         String code = "JAKR";
         int rentalDays = 4;


### PR DESCRIPTION
What does this PR do?
--------------------------
Removes reference to `Shed.class` to get the classloader for reading the resource files. Replaces the `getResourceAsStream` with a `FileInputStream`.

Why are you doing this?
--------------------------
Decoupling an unrelated class is cleanup from an earlier commit. Performing a live-read of the file system as opposed to reading an embedded resource enables live-updating of the data files for future feature enhancements. (Not yet implemented.)