### PR TITLE
bugfix: charged Monday if rental started on Sunday, July 5th.

### DIFF
--- a/src/main/java/office/CalendarEvaluator.java
+++ b/src/main/java/office/CalendarEvaluator.java
@@ -53,6 +53,8 @@ public class CalendarEvaluator {
                     dateSet.computeIfPresent(key, (k, v) -> false);
                 }
             // mask Labor Day
+            } else if (key.getMonth() == Month.JULY && (key.getDayOfMonth() == 5 || key.getDayOfMonth() == 6) && key.getDayOfWeek() == MONDAY) {
+                dateSet.computeIfPresent(key, (k, v) -> false);
             } else if (key.getMonth() == Month.SEPTEMBER && key.getDayOfWeek() == MONDAY && key.getDayOfMonth() <= 7) {
                 dateSet.computeIfPresent(key, (k, v) -> false);
             }

--- a/src/main/java/office/CalendarEvaluator.java
+++ b/src/main/java/office/CalendarEvaluator.java
@@ -44,17 +44,19 @@ public class CalendarEvaluator {
     public static void maskHolidays(final Map<LocalDate, Boolean> dateSet) {
         dateSet.forEach((key, value) -> {
             // mask July 4ths
-            if (key.getMonth() == Month.JULY && key.getDayOfMonth() == 4) {
-                if (key.getDayOfWeek() == SATURDAY) {
-                    dateSet.computeIfPresent(key.plusDays(2), (k, v) -> false);
-                } else if (key.getDayOfWeek() == SUNDAY) {
-                    dateSet.computeIfPresent(key.plusDays(1), (k, v) -> false);
-                } else {
+            if (key.getMonth() == Month.JULY) {
+                if (key.getDayOfMonth() == 4) {
+                    if (key.getDayOfWeek() == SATURDAY) {
+                        dateSet.computeIfPresent(key.plusDays(2), (k, v) -> false);
+                    } else if (key.getDayOfWeek() == SUNDAY) {
+                        dateSet.computeIfPresent(key.plusDays(1), (k, v) -> false);
+                    } else {
+                        dateSet.computeIfPresent(key, (k, v) -> false);
+                    }
+                } else if ((key.getDayOfMonth() == 5 || key.getDayOfMonth() == 6) && key.getDayOfWeek() == MONDAY) {
                     dateSet.computeIfPresent(key, (k, v) -> false);
                 }
             // mask Labor Day
-            } else if (key.getMonth() == Month.JULY && (key.getDayOfMonth() == 5 || key.getDayOfMonth() == 6) && key.getDayOfWeek() == MONDAY) {
-                dateSet.computeIfPresent(key, (k, v) -> false);
             } else if (key.getMonth() == Month.SEPTEMBER && key.getDayOfWeek() == MONDAY && key.getDayOfMonth() <= 7) {
                 dateSet.computeIfPresent(key, (k, v) -> false);
             }

--- a/src/test/java/office/CalendarEvaluatorTest.java
+++ b/src/test/java/office/CalendarEvaluatorTest.java
@@ -1,6 +1,5 @@
 package office;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -13,43 +12,32 @@ import static config.Common.dateFormatter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CalendarEvaluatorTest {
-
-    @Test
-    void daysToCharge() {
-    }
-
-    @Test
-    void getHolidaySet() {
-    }
-
     /*
     start date -> end date => expected response
      */
-    private static Stream<Arguments> provideDatesForJuly4th() {
+    private static Stream<Arguments> provideDates() {
         return Stream.of(
                 // before the 4th, expect none
-                Arguments.of(LocalDate.parse("07/01/20", dateFormatter), LocalDate.parse("07/03/20", dateFormatter), Set.of()),
-                // after the 4th, expect none
-                Arguments.of(LocalDate.parse("07/05/20", dateFormatter), LocalDate.parse("07/08/20", dateFormatter), Set.of()),
+                Arguments.of(LocalDate.parse("07/01/20", dateFormatter), 2, 2),
+                // after the 4th, but 4th was on weekend... don't count the 6th!!
+                Arguments.of(LocalDate.parse("07/05/20", dateFormatter), 3, 2),
                 // falls on a Saturday, returns the following Monday
-                Arguments.of(LocalDate.parse("07/01/20", dateFormatter), LocalDate.parse("07/05/20", dateFormatter), Set.of(LocalDate.parse("07/06/20", dateFormatter))),
+                Arguments.of(LocalDate.parse("07/01/20", dateFormatter), 4, 2),
                 // falls on a Sunday, returns the following Monday
-                Arguments.of(LocalDate.parse("07/01/21", dateFormatter), LocalDate.parse("07/07/21", dateFormatter), Set.of(LocalDate.parse("07/05/21", dateFormatter))),
+                Arguments.of(LocalDate.parse("07/01/21", dateFormatter), 6, 3),
                 // falls on a Monday, returns itself
-                Arguments.of(LocalDate.parse("07/01/22", dateFormatter), LocalDate.parse("07/07/22", dateFormatter), Set.of(LocalDate.parse("07/04/22", dateFormatter))),
+                Arguments.of(LocalDate.parse("07/01/22", dateFormatter), 6, 3),
                 // ends on a Monday, returns itself
-                Arguments.of(LocalDate.parse("07/01/22", dateFormatter), LocalDate.parse("07/04/22", dateFormatter), Set.of(LocalDate.parse("07/04/22", dateFormatter))),
+                Arguments.of(LocalDate.parse("07/01/22", dateFormatter), 3, 0),
                 // starts on a Monday, ignores it
-                Arguments.of(LocalDate.parse("07/04/22", dateFormatter), LocalDate.parse("07/07/22", dateFormatter), Set.of()),
-                // spans more than a year, returns both, offset to Mondays
-                Arguments.of(LocalDate.parse("07/01/20", dateFormatter), LocalDate.parse("07/07/21", dateFormatter), Set.of(LocalDate.parse("07/06/20", dateFormatter), LocalDate.parse("07/05/21", dateFormatter)))
+                Arguments.of(LocalDate.parse("07/04/22", dateFormatter), 3, 3)
         );
     }
 
     @ParameterizedTest
-    @MethodSource("provideDatesForJuly4th")
-    void test_findEffectiveJuly4ths(LocalDate startDate, LocalDate endDate, Set<LocalDate> expected) {
-        assertEquals(expected, CalendarEvaluator.findEffectiveJuly4ths(startDate, endDate));
+    @MethodSource("provideDates")
+    void test_calculateNumOfDaysToCharge(LocalDate startDate, int numOfRentalDays, long expected) {
+        assertEquals(expected, CalendarEvaluator.calculateNumOfDaysToCharge(startDate, numOfRentalDays, false, false));
     }
 
     /*
@@ -72,11 +60,5 @@ class CalendarEvaluatorTest {
                 // spans more than a year, returns both
                 Arguments.of(LocalDate.parse("09/01/20", dateFormatter), LocalDate.parse("09/07/21", dateFormatter), Set.of(LocalDate.parse("09/07/20", dateFormatter), LocalDate.parse("09/06/21", dateFormatter)))
         );
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideDatesForLaborDay")
-    void test_findLaborDays(LocalDate startDate, LocalDate endDate, Set<LocalDate> expected) {
-        assertEquals(expected, CalendarEvaluator.findLaborDays(startDate, endDate));
     }
 }

--- a/src/test/java/office/CalendarEvaluatorTest.java
+++ b/src/test/java/office/CalendarEvaluatorTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.LocalDate;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static config.Common.dateFormatter;
@@ -15,7 +14,7 @@ class CalendarEvaluatorTest {
     /*
     start date -> end date => expected response
      */
-    private static Stream<Arguments> provideDates() {
+    private static Stream<Arguments> provideDatesForJuly4th() {
         return Stream.of(
                 // before the 4th, expect none
                 Arguments.of(LocalDate.parse("07/01/20", dateFormatter), 2, 2),
@@ -34,31 +33,24 @@ class CalendarEvaluatorTest {
         );
     }
 
-    @ParameterizedTest
-    @MethodSource("provideDates")
-    void test_calculateNumOfDaysToCharge(LocalDate startDate, int numOfRentalDays, long expected) {
-        assertEquals(expected, CalendarEvaluator.calculateNumOfDaysToCharge(startDate, numOfRentalDays, false, false));
-    }
-
-    /*
-    start date -> end date => expected response
-     */
     private static Stream<Arguments> provideDatesForLaborDay() {
         return Stream.of(
                 // before the Labor Day, expect none
-                Arguments.of(LocalDate.parse("09/01/21", dateFormatter), LocalDate.parse("09/03/21", dateFormatter), Set.of()),
+                Arguments.of(LocalDate.parse("09/01/21", dateFormatter), 2, 2),
                 // after the Labor Day, expect none
-                Arguments.of(LocalDate.parse("09/07/21", dateFormatter), LocalDate.parse("09/21/21", dateFormatter), Set.of()),
-                // wrong month, expect none
-                Arguments.of(LocalDate.parse("07/07/21", dateFormatter), LocalDate.parse("07/21/21", dateFormatter), Set.of()),
+                Arguments.of(LocalDate.parse("09/07/21", dateFormatter), 14, 10),
                 // happy path
-                Arguments.of(LocalDate.parse("09/01/22", dateFormatter), LocalDate.parse("09/07/22", dateFormatter), Set.of(LocalDate.parse("09/05/22", dateFormatter))),
+                Arguments.of(LocalDate.parse("09/01/22", dateFormatter), 6, 3),
                 // ends on Labor day, finds it
-                Arguments.of(LocalDate.parse("09/01/22", dateFormatter), LocalDate.parse("09/05/22", dateFormatter), Set.of(LocalDate.parse("09/05/22", dateFormatter))),
+                Arguments.of(LocalDate.parse("09/01/22", dateFormatter), 4, 1),
                 // starts on Labor day, ignores it
-                Arguments.of(LocalDate.parse("09/05/22", dateFormatter), LocalDate.parse("09/07/22", dateFormatter), Set.of()),
-                // spans more than a year, returns both
-                Arguments.of(LocalDate.parse("09/01/20", dateFormatter), LocalDate.parse("09/07/21", dateFormatter), Set.of(LocalDate.parse("09/07/20", dateFormatter), LocalDate.parse("09/06/21", dateFormatter)))
+                Arguments.of(LocalDate.parse("09/05/22", dateFormatter), 2, 2)
         );
+    }
+
+    @ParameterizedTest
+    @MethodSource({"provideDatesForJuly4th", "provideDatesForLaborDay"})
+    void test_calculateNumOfDaysToCharge(LocalDate startDate, int numOfRentalDays, long expected) {
+        assertEquals(expected, CalendarEvaluator.calculateNumOfDaysToCharge(startDate, numOfRentalDays, false, false));
     }
 }

--- a/src/test/java/office/CheckoutTest.java
+++ b/src/test/java/office/CheckoutTest.java
@@ -268,6 +268,51 @@ class CheckoutTest {
                 Final charge: $1.49""", underTest.printRentalAgreement());
     }
 
+    @Test
+    void test_rental_starts_after_weekend_4th() {
+        // test values
+        String code = "JAKR";
+        int rentalDays = 3;
+        String checkoutDayString = "07/05/20";
+        int discountPercentage = 50;
+
+        // explicitly build expected outputs
+        Tool expectedTool = new Tool();
+        expectedTool.setCode(code);
+        expectedTool.setBrand("Ridgid");
+        expectedTool.setType("Jackhammer");
+        StaticValues expected = new StaticValues(
+                expectedTool,
+                rentalDays,
+                LocalDate.parse(checkoutDayString, dateFormatter),
+                discountPercentage,
+                LocalDate.parse("07/08/20", dateFormatter),
+                new BigDecimal("2.99"),
+                2, // no charge on Monday (deferred 4th of July)
+                new BigDecimal("5.98"),
+                new BigDecimal("2.99"), // 1.495 rounding up!
+                new BigDecimal("2.99")
+        );
+        // generate the rental agreement
+        Checkout underTest = new Checkout(Shed.getTool(code), rentalDays, LocalDate.parse(checkoutDayString, dateFormatter), discountPercentage);
+        // test the results
+        validateScenario(underTest, expected);
+        assertEquals("""
+                ************************************
+                Tool code: JAKR
+                Tool type: Jackhammer
+                Tool brand: Ridgid
+                Rental days: 3
+                Check out date: 07/05/20
+                Due date: 07/08/20
+                Daily rental charge: $2.99
+                Charge days: 2
+                Pre-discount charge: $5.98
+                Discount percent: 50%
+                Discount amount: $2.99
+                Final charge: $2.99""", underTest.printRentalAgreement());
+    }
+
     void validateScenario(Checkout input, StaticValues expected) {
         assertEquals(expected.getTool().getCode(), input.getTool().getCode(), "failed code");
         assertEquals(expected.getTool().getType(), input.getTool().getType(), "failed type");


### PR DESCRIPTION
What does this PR Do?
------------------------------
This PR fixes a bug that resulted in a charge applied on Monday, July 6th, 2020, for a rental that initiated July 5th. Simplifies the Holiday and weekend masking logic.

Why am I doing this?
------------------------------
Bugs are less than delightful.